### PR TITLE
Update nvim config and dependencies (ZED-133)

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -10,7 +10,7 @@
   "friendly-snippets": { "branch": "main", "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9" },
   "gitsigns.nvim": { "branch": "main", "commit": "2038c666bd9d8a0b7349a0b6ee00dc83104b9ecf" },
   "jj-diffconflicts": { "branch": "main", "commit": "a2aa9a247b56d2c1a6f6be81bcf41c5450cc82ff" },
-  "jj.nvim": { "branch": "main", "commit": "cffc74128a80398469085e01ff2e4001e330b800" },
+  "jj.nvim": { "branch": "main", "commit": "f217b16699e714e32df5c7616c0f71b70d49e11f" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
   "lazydev.nvim": { "branch": "main", "commit": "ff2cbcba459b637ec3fd165a2be59b7bbaeedf0d" },
   "lualine.nvim": { "branch": "master", "commit": "221ce6b2d999187044529f49da6554a92f740a96" },
@@ -37,7 +37,7 @@
   "registers.nvim": { "branch": "main", "commit": "c217f8f369e0886776cda6c94eab839b30a8940d" },
   "snacks.nvim": { "branch": "main", "commit": "882c996cf28183f4d63640de0b4c02ec886d01f2" },
   "telescope-fzf-native.nvim": { "branch": "main", "commit": "b25b749b9db64d375d782094e2b9dce53ad53a40" },
-  "telescope.nvim": { "branch": "master", "commit": "9377230aa5305d9e9aca4ed8dadf1070fb4aa9fc" },
+  "telescope.nvim": { "branch": "master", "commit": "427b576c16792edad01a92b89721d923c19ad60f" },
   "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" },
   "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" },
   "window-picker": { "branch": "main", "commit": "6382540b2ae5de6c793d4aa2e3fe6dbb518505ec" }

--- a/lua/plugins/dap.lua
+++ b/lua/plugins/dap.lua
@@ -241,9 +241,10 @@ return {
 
       if vim.fn.executable(bash_debug_adapter_bin) == 1 then
         local bashdb_dir = bash_debug_adapter_path .. "/extension/bashdb_dir"
-        local pathBash = vim.fn.executable("/opt/homebrew/bin/bash") == 1
-            and "/opt/homebrew/bin/bash"
-          or "/bin/bash"
+        local pathBash = vim.fn.exepath("bash")
+        if pathBash == "" then
+          pathBash = "/bin/bash"
+        end
 
         dap.adapters.bashdb = {
           type = "executable",

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -53,8 +53,17 @@ return {
           end
         end
 
-        -- Fallback to system python
-        return vim.fn.exepath("python3") or vim.fn.exepath("python") or "python"
+        -- Fallback to system Python. `exepath()` returns an empty string when
+        -- missing, and empty strings are truthy in Lua.
+        local python3 = vim.fn.exepath("python3")
+        if python3 ~= "" then
+          return python3
+        end
+        local python = vim.fn.exepath("python")
+        if python ~= "" then
+          return python
+        end
+        return "python"
       end
 
       -- LspAttach autocmd for on_attach logic (Neovim 0.12+ pattern)

--- a/tests/test_lsp_spec.lua
+++ b/tests/test_lsp_spec.lua
@@ -113,6 +113,13 @@ test("basedpyright config has settings.basedpyright.analysis", function()
     "basedpyright analysis settings missing")
 end)
 
+test("basedpyright pythonPath fallback is non-empty", function()
+  local cfg = captured_configs["basedpyright"]
+  local python_path = cfg.settings and cfg.settings.python and cfg.settings.python.pythonPath
+  assert_true(type(python_path) == "string" and python_path ~= "",
+    "basedpyright python.pythonPath should never be an empty exepath result")
+end)
+
 test("lua_ls integrates with lazydev-compatible workspace library", function()
   local cfg = captured_configs["lua_ls"]
   local lib = cfg.settings and cfg.settings.Lua and cfg.settings.Lua.workspace

--- a/tests/test_plugin_specs.lua
+++ b/tests/test_plugin_specs.lua
@@ -60,6 +60,7 @@ end)
 test("DAP config registers bash adapter when bash-debug-adapter is executable", function()
   -- Install rich mocks for the dap ecosystem.
   local orig_executable = vim.fn.executable
+  local orig_exepath = vim.fn.exepath
   local orig_sign_define = vim.fn.sign_define
   local orig_notify = vim.notify
   local orig_popen = io.popen
@@ -100,12 +101,18 @@ test("DAP config registers bash adapter when bash-debug-adapter is executable", 
     return { setup = function(p) dap_python_setup_arg = p end }
   end
 
-  -- Force bash-debug-adapter and homebrew bash to "exist"
+  -- Force bash-debug-adapter to "exist"; bash itself should be resolved from PATH.
   vim.fn.executable = function(path)
-    if type(path) == "string" and (path:match("bash%-debug%-adapter") or path == "/opt/homebrew/bin/bash") then
+    if type(path) == "string" and path:match("bash%-debug%-adapter") then
       return 1
     end
     return 0
+  end
+  vim.fn.exepath = function(name)
+    if name == "bash" then
+      return "/mock/bin/bash"
+    end
+    return ""
   end
   vim.fn.sign_define = function() return 0 end
   vim.notify = function() end
@@ -115,6 +122,7 @@ test("DAP config registers bash adapter when bash-debug-adapter is executable", 
 
   local restore = function()
     vim.fn.executable = orig_executable
+    vim.fn.exepath = orig_exepath
     vim.fn.sign_define = orig_sign_define
     vim.notify = orig_notify
     io.popen = orig_popen
@@ -150,8 +158,8 @@ test("DAP config registers bash adapter when bash-debug-adapter is executable", 
   local cfg = dap_mock.configurations.sh[1]
   assert_eq(cfg.type, "bashdb", "sh config should use bashdb adapter")
   assert_eq(type(cfg.cwd), "function", "cwd should be a function (resolved at launch time)")
-  assert_eq(cfg.pathBash, "/opt/homebrew/bin/bash",
-    "homebrew bash path should be preferred when available")
+  assert_eq(cfg.pathBash, "/mock/bin/bash",
+    "bash path should be resolved from PATH with vim.fn.exepath")
 end)
 
 test("DAP config skips bash adapter when bash-debug-adapter missing", function()
@@ -220,25 +228,41 @@ end)
 -- ── Treesitter ────────────────────────────────────────────────────────────────
 test("Treesitter config keeps expected language set", function()
   local treesitter_spec = require("plugins.treesitter")[1]
-  local captured
+  local installed
 
-  local orig_ts_configs = package.loaded["nvim-treesitter.configs"]
-  package.loaded["nvim-treesitter.configs"] = {
-    setup = function(opts) captured = opts end,
-  }
+  local orig_ts = package.loaded["nvim-treesitter"]
+  local orig_preload_ts = package.preload["nvim-treesitter"]
+  local orig_create_autocmd = vim.api.nvim_create_autocmd
+  local orig_create_augroup = vim.api.nvim_create_augroup
 
-  local ok, err = pcall(treesitter_spec.config)
+  package.loaded["nvim-treesitter"] = nil
+  package.preload["nvim-treesitter"] = function()
+    return {
+      install = function(langs)
+        installed = langs
+        return {
+          await = function() end,
+        }
+      end,
+      indentexpr = function() return "" end,
+    }
+  end
+  vim.api.nvim_create_autocmd = function() return 1 end
+  vim.api.nvim_create_augroup = function() return 1 end
 
-  package.loaded["nvim-treesitter.configs"] = orig_ts_configs
+  local ok, err = xpcall(treesitter_spec.config, debug.traceback)
+
+  package.loaded["nvim-treesitter"] = orig_ts
+  package.preload["nvim-treesitter"] = orig_preload_ts
+  vim.api.nvim_create_autocmd = orig_create_autocmd
+  vim.api.nvim_create_augroup = orig_create_augroup
 
   if not ok then error(err) end
 
-  assert_true(type(captured) == "table", "Treesitter config should call setup")
-  local ensure = captured.ensure_installed or {}
+  assert_true(type(installed) == "table", "Treesitter config should call install")
   for _, lang in ipairs({ "python", "lua", "vim", "vimdoc", "query" }) do
-    assert_true(vim.tbl_contains(ensure, lang), "ensure_installed should include " .. lang)
+    assert_true(vim.tbl_contains(installed, lang), "install list should include " .. lang)
   end
-  assert_eq(captured.auto_install, true, "auto_install should be enabled")
 end)
 
 -- ── JJ plugin keymaps ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- refresh Lazy lockfile pins for jj.nvim and telescope.nvim
- resolve bash DAP path from PATH with a /bin/bash fallback
- make basedpyright Python fallback robust against empty exepath() results
- update regression specs for current nvim-treesitter/main behavior and new fallback coverage

Fixes ZED-133

## Verification
- ./tests/run_single_test.sh tests/test_lsp_spec.lua
- ./tests/run_single_test.sh tests/test_plugin_specs.lua
- ./tests/run_all_tests.sh
- ./tests/run_all_tests.sh --integration
- ./tests/headless_startup.sh
- git diff --check

## Notes
- Left local .codex/hooks.json uncommitted because it was unrelated pre-existing worktree state.